### PR TITLE
Remove useless network-store build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,15 +16,6 @@ jobs:
         with:
           java-version: 11
 
-      - name: Checkout network store sources
-        uses: actions/checkout@v1
-        with:
-          repository: powsybl/powsybl-network-store
-          ref: refs/heads/master
-
-      - name: Build and install network store client with Maven
-        run: mvn --batch-mode -Pclient -DskipTests=true --file ../powsybl-network-store/pom.xml install
-
       - name: Checkout geo-data sources
         uses: actions/checkout@v1
         with:


### PR DESCRIPTION
Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Cleanup


**What is the current behavior?** *(You can also link to an open issue here)*
CI builds network-store snapshot


**What is the new behavior (if this is a feature change)?**
CI does not build network-store at all



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO

**Other information**:
was a copypaste error ? or maybe it was needed at some point but is no longer needed