### PR TITLE
fix artifact ids to follow our conventions

### DIFF
--- a/cgmes-gl-distribution/pom.xml
+++ b/cgmes-gl-distribution/pom.xml
@@ -16,14 +16,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <packaging>pom</packaging>
-    <artifactId>cgmes-gl-distribution</artifactId>
+    <artifactId>powsybl-cgmes-gl-distribution</artifactId>
     <name>CGMES GL distribution</name>
     <description>CGMES GL distribution module</description>
 
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>cgmes-gl-server</artifactId>
+            <artifactId>powsybl-cgmes-gl-server</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/cgmes-gl-server/pom.xml
+++ b/cgmes-gl-server/pom.xml
@@ -15,7 +15,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>cgmes-gl-server</artifactId>
+    <artifactId>powsybl-cgmes-gl-server</artifactId>
     <name>CGMES GL server</name>
     <description>CGMES GL server</description>
 


### PR DESCRIPTION
Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bugfix



**What is the current behavior?** *(You can also link to an open issue here)*
artifacts without the powsybl- prefix
jib builds the wrong image name by default:
[INFO] Built image to Docker daemon as cgmes/gl-server


**What is the new behavior (if this is a feature change)?**
artifacts with the powsybl- prefix. This makes our automatic jib:dockerBuild pick the right image name:
[INFO] Built image to Docker daemon as powsybl/cgmes-gl-server

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO
